### PR TITLE
Bump faraday to 1.10

### DIFF
--- a/lib/newgistics/api.rb
+++ b/lib/newgistics/api.rb
@@ -14,7 +14,7 @@ module Newgistics
 
     def connection
       @connection ||= Faraday.new(url: api_base_url) do |faraday|
-        faraday.response :logger, Newgistics.logger, bodies: true
+        faraday.response :logger, Newgistics.logger
         faraday.adapter Faraday.default_adapter
       end
     end

--- a/lib/newgistics/version.rb
+++ b/lib/newgistics/version.rb
@@ -1,3 +1,3 @@
 module Newgistics
-  VERSION = "2.6.0".freeze
+  VERSION = "2.6.1".freeze
 end

--- a/lib/newgistics/version.rb
+++ b/lib/newgistics/version.rb
@@ -1,3 +1,3 @@
 module Newgistics
-  VERSION = "2.5.0".freeze
+  VERSION = "2.6.0".freeze
 end

--- a/newgistics.gemspec
+++ b/newgistics.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "virtus", "~> 1.0"
   spec.add_dependency "nokogiri", "~> 1.8"
-  spec.add_dependency "faraday", "~> 0.9"
+  spec.add_dependency "faraday", "~> 1.10"
   spec.add_dependency "tzinfo", "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"


### PR DESCRIPTION

* Bump faraday to 1.10. this is required to upgrade to ruby 3