### PR TITLE
[CXOP-318] Better logger config

### DIFF
--- a/lib/newgistics.rb
+++ b/lib/newgistics.rb
@@ -54,31 +54,19 @@ require "newgistics/version"
 require "newgistics/xml_marshaller"
 
 module Newgistics
-  def self.configuration
-    @configuration ||= Configuration.new
-  end
-
-  def self.api
-    @api ||= Api.new
-  end
-
-  def self.logger
-    @logger ||= DefaultLogger.build
-  end
-
-  def self.logger=(logger)
-    @logger = logger
-  end
-
-  def self.time_zone
-    configuration.time_zone
-  end
-
-  def self.local_time_zone
-    configuration.local_time_zone
-  end
-
-  def self.configure
-    yield(configuration)
+  class << self
+    delegate :time_zone, :local_time_zone, :logger, :logger=, to: :@configuration
+  
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  
+    def api
+      @api ||= Api.new
+    end
+  
+    def configure
+      yield(configuration)
+    end
   end
 end

--- a/lib/newgistics/api.rb
+++ b/lib/newgistics/api.rb
@@ -14,8 +14,16 @@ module Newgistics
 
     def connection
       @connection ||= Faraday.new(url: api_base_url) do |faraday|
-        faraday.response :logger, Newgistics.logger
-        faraday.adapter Faraday.default_adapter
+        faraday.adapter(Faraday.default_adapter)
+        faraday.response(
+          :logger,
+          Newgistics.configuration.logger,
+          {
+            headers: Newgistics.configuration.log_http_headers,
+            bodies: Newgistics.configuration.log_http_bodies,
+            errors: Newgistics.configuration.log_http_errors,
+          },
+        ) if Newgistics.configuration.log_http
       end
     end
 

--- a/lib/newgistics/configuration.rb
+++ b/lib/newgistics/configuration.rb
@@ -1,7 +1,7 @@
 module Newgistics
   class Configuration
     attr_reader :time_zone, :local_time_zone
-    attr_accessor :api_key, :api_base_url, :logger, :log_http
+    attr_accessor :api_key, :api_base_url, :logger, :log_http, :log_http_headers, :log_http_bodies, :log_http_error
 
     def initialize
       self.time_zone = "America/Denver"
@@ -32,15 +32,28 @@ module Newgistics
       @log_http || false
     end
 
+    def log_http_headers=(value)
+      @log_headers = value
+    end
+
     def log_http_headers
       @log_headers || false
+    end
+
+    def log_http_bodies=(value)
+      @log_bodies = value
     end
 
     def log_http_bodies
       @log_bodies || false
     end
 
+    def log_http_errors=(value)
+      @log_errors = value
+    end
+
     def log_http_errors
       @log_errors || true
+    end
   end
 end

--- a/lib/newgistics/configuration.rb
+++ b/lib/newgistics/configuration.rb
@@ -1,7 +1,7 @@
 module Newgistics
   class Configuration
     attr_reader :time_zone, :local_time_zone
-    attr_accessor :api_key, :api_base_url, :logger
+    attr_accessor :api_key, :api_base_url, :logger, :log_http
 
     def initialize
       self.time_zone = "America/Denver"
@@ -20,8 +20,27 @@ module Newgistics
       @local_time_zone = TimeZone.new(name)
     end
 
+    def logger
+      @logger ||= DefaultLogger.build
+    end
+
     def logger=(_logger)
       @logger = _logger
     end
+
+    def log_http
+      @log_http || false
+    end
+
+    def log_http_headers
+      @log_headers || false
+    end
+
+    def log_http_bodies
+      @log_bodies || false
+    end
+
+    def log_http_errors
+      @log_errors || true
   end
 end

--- a/lib/newgistics/configuration.rb
+++ b/lib/newgistics/configuration.rb
@@ -1,7 +1,7 @@
 module Newgistics
   class Configuration
     attr_reader :time_zone, :local_time_zone
-    attr_accessor :api_key, :api_base_url
+    attr_accessor :api_key, :api_base_url, :logger
 
     def initialize
       self.time_zone = "America/Denver"
@@ -18,6 +18,10 @@ module Newgistics
 
     def local_time_zone=(name)
       @local_time_zone = TimeZone.new(name)
+    end
+
+    def logger=(_logger)
+      @logger = _logger
     end
   end
 end

--- a/lib/newgistics/default_logger.rb
+++ b/lib/newgistics/default_logger.rb
@@ -3,8 +3,11 @@ require 'logger'
 module Newgistics
   class DefaultLogger
     def self.build
-      return Newgistics.Configuration.logger if Newgistics.Configuration.logger.present?
-      return Rails.logger if defined?(Rails)
+      Object.const_defined?("Rails") ? Rails.logger : build_logger
+    end
+
+    private 
+    def self.build_logger
       Logger.new(STDOUT).tap do |logger|
         logger.level = Logger::INFO
       end

--- a/lib/newgistics/default_logger.rb
+++ b/lib/newgistics/default_logger.rb
@@ -3,6 +3,8 @@ require 'logger'
 module Newgistics
   class DefaultLogger
     def self.build
+      return Newgistics.Configuration.logger if Newgistics.Configuration.logger.present?
+      return Rails.logger if defined?(Rails)
       Logger.new(STDOUT).tap do |logger|
         logger.level = Logger::INFO
       end

--- a/lib/newgistics/version.rb
+++ b/lib/newgistics/version.rb
@@ -1,3 +1,3 @@
 module Newgistics
-  VERSION = "2.6.1".freeze
+  VERSION = "2.6.2".freeze
 end

--- a/newgistics.gemspec
+++ b/newgistics.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", "~> 0.9"
   spec.add_dependency "tzinfo", "~> 2.0"
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Add the ability for the Newgistics logger to be configured, and to use rails logging automatically.

Usage:
```ruby
  config.logger = Rails.logger
  config.log_http = false
  config.log_http_headers = false
  config.log_http_bodies = false
  config.log_http_errors = false
```

See the [Faraday logging documentation ](https://lostisland.github.io/faraday/middleware/logger#include-and-exclude-headersbodies)for more details.


| Attribute | Description|
| --------- | ----------- |
| `log_http` | Determines if `faraday.response` is called. Defaults to false. |
| `log_http_headers` | Tells Faraday to log the headers or not. Has no effect if `log_http` is false. Defaults to false. |
| `log_http_bodies` | Tells Faraday to log response body or not. Has no effect if `log_http` is false. Defaults to false. |
| `log_http_errors` | Tells Faraday to log the errors or not. Has no effect if `log_http` is false. Defaults to true. I haven't seen this one in action. |

### How to Test
* Checkout this repo at the same level as your quip repo.
* Update `Gemfile` with
```ruby
gem "newgistics", "~> 2.6.1", path: "../newgistics-ruby"
```

I had trouble with local caching, and with spring. Before starting the rails console, I ran,

```bash
rm -rf  /usr/local/bundle/bundler/gems/newgistics-ruby*
bin/spring stop
bundle install
bundle exec rails c
```

Make sure your local DB has orders. I reseeded my DB, then ran in rails console, 
```ruby
Orders.all.update_all(fulfillment_provider: 'newgistics', sent_to_newgistics_at: 1.minute.ago, needs_third_party_sync: true)
```

You're finally ready. Test it out by running,

```ruby
NewgisticsShipmentSyncWorker.new(10).perform
```

There should no HTTP chatter in the logs. If you're using `YamlLogFormatter`, you should see something like,

```yml
Running for minutes: all
  logger:
    name: NewgisticsShipmentSyncWorker
    method_name: perform
    version: f422ff4fce572e06
Expiring old orders
  logger:
    name: NewgisticsShipmentSyncWorker
    method_name: expire_old_orders
    version: f422ff4fce572e06
Syncing all orders
  logger:
    name: NewgisticsShipmentSyncWorker
    method_name: sync_all_orders
    version: f422ff4fce572e06
Syncing 1 intervals (length: 60)
  logger:
    name: NewgisticsShipmentSyncWorker
    method_name: sync_intervals
    version: f422ff4fce572e06
Fetching shipments between 2022-12-01 16:48:00 UTC and 2022-12-01 16:49:00 UTC
  logger:
    name: NewgisticsShipmentSyncWorker
    method_name: block in concurrent_requests_for
    version: f422ff4fce572e06
All status requests have returned
  logger:
    name: NewgisticsShipmentSyncWorker
    method_name: sync_intervals
    version: f422ff4fce572e06
```

In `config/initializers/newgistics.rb`, add and play around with,

```ruby
  config.logger = Rails.logger
  config.log_http = false
  config.log_http_headers = false
  config.log_http_bodies = false
```

Close the console (`reload!` was not sufficient for me) and restart it. Rerun the worker command. Does it perform as expected?
